### PR TITLE
This should fix build issues on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(assimp_py)
 set(CMAKE_C_STANDARD 99)
-find_package(Python REQUIRED COMPONENTS Interpreter Development)
+find_package(Python ${REQUESTED_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
 # use ccache to speed up builds if it is available
 find_program(CCACHE_FOUND ccache)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import re
 import pathlib
 import platform
@@ -7,6 +8,8 @@ import subprocess
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
+
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 class CMakeExtension(Extension):
 
@@ -47,6 +50,9 @@ class CMakeBuild(build_ext):
         cmake_args = [
             '-DCMAKE_BUILD_TYPE=' + cfg,
             '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + str(extdir.parent.absolute()),
+
+            # Tells cmake which python version to use for this build
+            '-DREQUESTED_PYTHON_VERSION=' + PYTHON_VERSION,
 
             # This is the only reliable way I could find to get extension name on all platforms
             # Used within CMakeLists.txt


### PR DESCRIPTION
The issue was that FindPython was looking for the most recent Python version on the entire system. And it happened to find Python 3.9 somewhere, thus builds on <3.9 failed (why that only happens on Windows is beyond me though).

This should fix things.