### PR TITLE
Updated GitHub Actions for Python 3.13, added new deploy Action and fixed mac universal2 build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,22 +14,22 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        pip install pytest build
     - name: Install Package
       run: |
-        python setup.py install
+        python -m build
     - name: Test with pytest
       run: |
         pytest tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest build
+        pip install pytest
     - name: Install Package
       run: |
-        python -m build
+        python -m pip install .
     - name: Test with pytest
       run: |
         pytest tests

--- a/.github/workflows/python-publish-manylinux.yml
+++ b/.github/workflows/python-publish-manylinux.yml
@@ -1,9 +1,7 @@
 name: PyPI ManyLinux
 
 on:
-  push:
-    branches:
-      - "master"
+ workflow_dispatch:
 #   release:
 #     types: [created]
 

--- a/.github/workflows/python-publish-winmac.yml
+++ b/.github/workflows/python-publish-winmac.yml
@@ -4,8 +4,7 @@
 name: PyPI WinMac
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,8 +2,18 @@ name: Publish assimp-py to PyPI
 
 on:
   workflow_dispatch:
+    inputs:
+      pypi_target:
+        description: 'Deploy to Production or Test PyPI'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - test
+      
   release:
-    types: [released]
+    types: [published]
 
 env:
   CIBW_BUILD: cp3*
@@ -182,12 +192,17 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.10.3
+      - name: Publish to Production PyPI
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.pypi_target == 'production') || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        uses: pypa/gh-action-pypi-publish@v1.10.3
         with:
           user: __token__
-          # Uncomment to publish to production PyPI:
-          # password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_TOKEN }}
 
-          # Uncomment to publish to test PyPI (https://test.pypi.org):
-          password: ${{ secrets.testpypi_password }}
+      - name: Publish to Test PyPI
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.pypi_target == 'test') || (github.event_name == 'release' && github.event.release.prerelease) }}
+        uses: pypa/gh-action-pypi-publish@v1.10.3
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,193 @@
+name: Publish assimp-py to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+env:
+  CIBW_BUILD: cp3*
+  CIBW_SKIP: cp36-* cp37-* cp38-*
+  CIBW_TEST_REQUIRES: pytest
+  CIBW_TEST_COMMAND: pytest {project}/tests
+
+jobs:
+  build_wheels_windows:
+    name: Build wheels on Windows (${{ matrix.arch }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [AMD64, ARM64]
+    env:
+      CIBW_ARCHS: ${{matrix.arch}}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cibuildwheel==2.21.3
+
+    - name: Build Python wheels
+      run: python -m cibuildwheel --output-dir wheelhouse
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: artifact-win-${{matrix.arch}}
+        path: ./wheelhouse/*.whl
+
+  build_wheels_mac:
+    name: Build wheels on MacOS (universal2)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]  # macos-latest (ARM64), macos-12 (Intel)
+        
+    env:
+      CIBW_ARCHS: universal2
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Set up Python
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-mac-universal2
+          path: ./wheelhouse/*.whl
+          
+  build_wheels_manylinux:
+    name: Build wheels on ${{ matrix.distro }} for ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [manylinux2014, manylinux_2_28]
+        arch: [x86_64, aarch64, s390x, ppc64le]
+        include:
+          - distro: manylinux2014
+            arch: i686
+        
+    env:
+      CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.distro }}
+      CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.distro }}
+      CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.distro }}
+      CIBW_MANYLINUX_S390X_IMAGE: ${{ matrix.distro }}
+      CIBW_MANYLINUX_PPC64LE_IMAGE: ${{ matrix.distro }}
+      CIBW_BUILD: cp3*-manylinux*
+      CIBW_ARCHS: ${{matrix.arch}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
+        uses: docker/setup-qemu-action@v3
+
+      - uses: actions/setup-python@v5
+        name: Set up Python
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.distro }}-${{matrix.arch}}
+          path: ./wheelhouse/*.whl
+        
+  build_wheels_musllinux:
+    name: Build wheels on musllinux_1_2 for ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, i686, aarch64, s390x, ppc64le, armv7l]
+        
+    env:
+      CIBW_MUSLLINUX_X86_64_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_I686_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_AARCH64_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_S390X_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_PPC64LE_IMAGE: musllinux_1_2
+      CIBW_MUSLLINUX_ARMV7L_IMAGE: musllinux_1_2
+      CIBW_BUILD: cp3*-musllinux*
+      CIBW_ARCHS: ${{matrix.arch}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: ${{ matrix.arch != 'x86_64' && matrix.arch != 'i686' }}
+        uses: docker/setup-qemu-action@v3
+
+      - uses: actions/setup-python@v5
+        name: Set up Python
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-musllinux-${{matrix.arch}}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.13'
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-source
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels_windows, build_wheels_mac, build_wheels_manylinux, build_wheels_musllinux, build_sdist]
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: artifact-*
+          merge-multiple: true
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.10.3
+        with:
+          user: __token__
+          # Uncomment to publish to production PyPI:
+          # password: ${{ secrets.pypi_password }}
+
+          # Uncomment to publish to test PyPI (https://test.pypi.org):
+          password: ${{ secrets.testpypi_password }}
+          repository-url: https://test.pypi.org/legacy/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ else()
     find_package(Python ${REQUESTED_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 endif()
 
+# build for universal2
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 
 # use ccache to speed up builds if it is available
 find_program(CCACHE_FOUND ccache)
@@ -31,8 +33,11 @@ endif()
 
 add_subdirectory(assimp)
 
+# build for universal2
+set_property(DIRECTORY assimp PROPERTY CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+
 # -- build the python extension
-include_directories(assimp/include ${Python_INCLUDE_DIRS})
+include_directories(assimp/include ${PROJECT_BINARY_DIR}/assimp/include ${Python_INCLUDE_DIRS})
 link_directories(${Python_LIBRARY_DIRS})
 add_library(assimp_py SHARED assimp_py.c)
 
@@ -41,7 +46,7 @@ if(UNIX AND NOT APPLE)
     # explicitly linking z and rt prevents the error related to that 
     target_link_libraries(assimp_py assimp z rt)
 elseif(APPLE)
-    target_link_libraries(assimp_py "-undefined dynamic_lookup")
+    target_link_libraries(assimp_py assimp "-undefined dynamic_lookup")
 else()
     target_link_libraries(assimp_py assimp)
 endif()

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,9 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     ext_modules=[CMakeExtension("assimp_py")],
     cmdclass={


### PR DESCRIPTION
Hi @ranjian0 

I've noticed that assimp_py doesn't have a release for Python 3.12 and Python 3.13 yet.
Looking at your profile I assumed you currently don't have a lot of time to work on your projects, so I decided to update the project accordingly myself.

I'll walk you through the changes I have made:

## Updated Python to 3.9 - 3.13
+ Listed support for 3.12 and 3.13 in setup.py
+ I've updated the Python versions tested in python-package.yml to include 3.12 and 3.13

## Updated workflow actions
+ Updated actions/checkout to v4
+ Updated actions/setup-python to v5

## Switched to building with pip install
Running `python setup.py install` directly is deprecated by now. 
You can use the build module or `pip install`.
Using `build` builds sdist and a wheel, but it doesn't install it automatically.
```
pip install build
python -m build
```

```
pip install .
```

I've updated python-package.yml accordingly.

## Created a working deploy action
When updating the project I noticed you were in the process of automating the build and deployment of assimp_py. 
python-publish-manylinux.yml seemed to be working, though using some deprecated modules and python-publish-winmac.yml seemed to only create a source distribution, presumably because the build didn't run successfully.

Previously you were using [RalfG/python-wheels-manylinux-build](https://github.com/RalfG/python-wheels-manylinux-build) to build your manylinux wheels, which is superseded by cibuildwheel.

[pypa/cibuildwheel](https://github.com/pypa/cibuildwheel) is a great tool for wheel building automation. 
Using cibuildwheel you no longer need multiple GitHub Actions for different operating systems, thus I created a new deployment action, simply called python-publish.yml.

## New Publish Action
The new action might look a bit complicated at first.
I'll walk you through it.
```yml
on:
  workflow_dispatch:
  release:
    types: [released]
```
I've set the trigger to released releases (i.e. the workflow runs when you create a release that isn't a prerelease) and to workflow_dispatch, which means you can run the Action from its respective page in your GitHub repository.
I've added workflow_dispatch for testing purposes. You can keep it or remove it, whichever way you like.

```yml
env:
  CIBW_BUILD: cp3*
  CIBW_SKIP: cp36-* cp37-* cp38-*
  CIBW_TEST_REQUIRES: pytest
  CIBW_TEST_COMMAND: pytest {project}/tests
```
These are environment variables for cibuildwheel.
1. `CIBW_BUILD: cp3*` tells cibuildwheel to build any CPython 3.X wheels
2. `CIBW_SKIP: cp36-* cp37-* cp38-*` tells cibuildwheel not to build 3.6, 3.7, 3.8 wheels. (I think by now cibuildwheel might no longer build these by default, but I kept them to be sure)
3. `CIBW_TEST_REQUIRES: pytest` tells cibuildwheel to install pytest for testing
4. `CIBW_TEST_COMMAND: pytest {project}/tests` tells cibuildwheel how to run the test command. If the test fails, the build will stop and nothing gets uploaded. This makes sure you don't upload any broken builds.

### Jobs
There are two layers of jobs:
1. Build wheels
  + build_wheels_windows[AMD64, ARM64]
  + build_wheels_mac (universal2)
  + build_wheels_manylinux[2014, 2_28][x86_64, aarch64, s390x, ppc64le, (i686)]
  + build_wheels_musllinux[x86_64, i686, aarch64, s390x, ppc64le, armv7l]
  + build_sdist
2. Upload wheels (only runs if all steps of the previous layer were successful)
  + upload_pypi

The first layer creates the wheels for Python 3.9 - 3.13 on windows, mac, manylinux2014, manylinux2_28, musllinux1_2 and a source distribution. The wheels are created for different architectures.
cibuildwheel handles this.
Building the wheels for aarch64, s390x, ppc64le and armv7l takes a while, because those architectures need to be emulated.

It was quite a challenge to get the universal2 builds to happen. I had to slightly adjust CMakeLists.txt to get it to work. I'm not an expert on cmake, so please double check that my changes are okay. Since the builds on mac run and the tests succeed too I think it's fine.

Every build step generates an artifact (zip file) which you can see in the summary section of the Action. These contain the generated wheels. The second layer uses these to collect the wheels.

The second layer only executes if all wheels were successfully built and tested.
Its purpose is to download the artifacts and upload them all to PyPI.
This requires some setup on your end.
I believe authenticating with username and password from GitHub Actions is no longer permitted. 
You have to use an API token or a [trusted publisher](https://docs.pypi.org/trusted-publishers/).
A Trusted Publisher means telling PyPI that its safe to accept deployment from a specific CI workflow (such as python-publish.yml). There are no API keys or passwords that can leak.
To set up an API token, log in to [PyPI](https://pypi.org/) and generate one in the settings.
You also need to have two factor authentication enabled on PyPI. Otherwise you're not allowed to publish new releases.

For the time being I've set up python-publish.yml so that it publishes to the [Test PyPI](https://test.pypi.org/), so you can test the setup before actually publishing a new version.
Use this setup to publish to the production PyPI:
```yml
# Uncomment to publish to production PyPI:
password: ${{ secrets.pypi_password }}

# Uncomment to publish to test PyPI (https://test.pypi.org):
# password: ${{ secrets.testpypi_password }}
# repository-url: https://test.pypi.org/legacy/
```
Feel free to rename the secret to your liking, such as `pypi_token`.

All of these changes should make it trivial for you to add support for a new Python version or improve the project with minimal effort.

PS.: I kept python-package-manylinux.yml and python-package-winmac.yml for the time being. If everything works as expected, feel free to remove them.
Also, make sure to update the GitHub Actions status badge in the Readme.